### PR TITLE
tests: base all fedimint-ln-tests on cln gateways

### DIFF
--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -14,6 +14,7 @@ use fedimint_core::config::{
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::module::{DynServerModuleInit, IServerModuleInit};
 use fedimint_core::task::{MaybeSend, MaybeSync, TaskGroup};
+use fedimint_core::util::SafeUrl;
 use fedimint_logging::{TracingSetup, LOG_TEST};
 use tempfile::TempDir;
 use tracing::info;
@@ -193,7 +194,11 @@ impl Fixtures {
         match Fixtures::is_real_test() {
             true => BitcoinRpcConfig {
                 kind: "esplora".to_string(),
-                url: "http://127.0.0.1:50002".parse().unwrap(),
+                url: SafeUrl::parse(&format!(
+                    "http://127.0.0.1:{}/",
+                    env::var("FM_PORT_ESPLORA").unwrap_or(String::from("50002"))
+                ))
+                .expect("Failed to parse default esplora server"),
             },
             false => self.bitcoin_rpc.clone(),
         }

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -27,9 +27,9 @@ fn fixtures() -> Fixtures {
 
 /// Setup a gateway connected to the fed and client
 async fn gateway(fixtures: &Fixtures, fed: &FederationTest) -> GatewayTest {
-    let lnd = fixtures.lnd().await;
+    let cln = fixtures.cln().await;
     let mut gateway = fixtures
-        .new_gateway(lnd, 0, Some(DEFAULT_GATEWAY_PASSWORD.to_string()))
+        .new_gateway(cln, 0, Some(DEFAULT_GATEWAY_PASSWORD.to_string()))
         .await;
     gateway.connect_fed(fed).await;
     gateway
@@ -201,8 +201,8 @@ async fn gateway_protects_preimage_for_payment() -> anyhow::Result<()> {
     let (op, outpoint) = client2_dummy_module.print_money(sats(10000)).await?;
     client2.await_primary_module_output(op, outpoint).await?;
 
-    let cln = fixtures.cln().await;
-    let invoice = cln.invoice(Amount::from_sats(100), None).await?;
+    let lnd = fixtures.lnd().await;
+    let invoice = lnd.invoice(Amount::from_sats(100), None).await?;
 
     // Pay invoice with client1
     let OutgoingLightningPayment {
@@ -256,8 +256,8 @@ async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
     let (op, outpoint) = dummy_module.print_money(sats(1000)).await?;
     client.await_primary_module_output(op, outpoint).await?;
 
-    let cln = fixtures.cln().await;
-    let invoice = cln.invoice(Amount::from_sats(100), None).await?;
+    let lnd = fixtures.lnd().await;
+    let invoice = lnd.invoice(Amount::from_sats(100), None).await?;
 
     // Pay the invoice for the first time
     let OutgoingLightningPayment {

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -51,7 +51,7 @@ fi
 
 # Switch to electrum and run wallet tests
 export FM_BITCOIN_RPC_KIND="electrum"
-export FM_BITCOIN_RPC_URL="tcp://127.0.0.1:50001"
+export FM_BITCOIN_RPC_URL="tcp://127.0.0.1:$FM_PORT_ELECTRS"
 
 if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "electrs" ]; then
   >&2 echo "### Testing against electrs"
@@ -62,7 +62,7 @@ fi
 
 # Switch to esplora and run wallet tests
 export FM_BITCOIN_RPC_KIND="esplora"
-export FM_BITCOIN_RPC_URL="http://127.0.0.1:50002"
+export FM_BITCOIN_RPC_URL="http://127.0.0.1:$FM_PORT_ESPLORA"
 
 if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "esplora" ]; then
   >&2 echo "### Testing against esplora"


### PR DESCRIPTION
While LND gateways are still limited by the number of HTCL subs that can be opened in parallel we base fedimint-ln-tests suite on CLN gateways. We can revert this patch after https://github.com/fedimint/fedimint/issues/3596 is fixed.

Note, the LND node and gateway is still used in the test suites, but only in places that avoid a race by multiple test instances to establish HTLC subs to the same node